### PR TITLE
Pass filename to jsxgettext

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,9 @@ function loader(content) {
   }, loaderUtils.parseQuery(this.query));
   if (!opts.keyword) opts.keyword = ['gettext'];
   if (!opts.output || !opts.outputDir) throw new Error('jsxgettext-loader needs output to be configured');
-  var result = jsxgettext.generate([content], opts);
+  var sources = {};
+  sources[this.resourcePath] = content;
+  var result = jsxgettext.generate(sources, opts);
   fs.writeFileSync(path.join(opts.outputDir, opts.output), result, 'utf-8');
   return content;
 }


### PR DESCRIPTION
This will result in the filename to be present in the references of the POT file.

I wrote a small jsxgettext loader as proof of concept myself, before I discovered your loader.
In my loader I did this, but **I did not test it in your code**.

So if you could add it to your loader I would be very happy :) But test it first.

Also you might consider adding a link to your repo in the package.json so that it can be discovered from the npm registry entry.
